### PR TITLE
fix(server): configure HTTP server timeouts

### DIFF
--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -19,6 +19,18 @@ import (
 type AdminConfig struct {
 	// Addr is the listen address (e.g., "127.0.0.1:9090").
 	Addr string
+	// ReadHeaderTimeout limits how long the server spends reading request headers.
+	// Default: 5s.
+	ReadHeaderTimeout time.Duration
+	// ReadTimeout limits how long the server spends reading the full request.
+	// Default: 15s.
+	ReadTimeout time.Duration
+	// WriteTimeout limits how long the server spends writing a response.
+	// Default: 30s.
+	WriteTimeout time.Duration
+	// IdleTimeout limits how long keep-alive connections remain idle.
+	// Default: 120s.
+	IdleTimeout time.Duration
 }
 
 // AdminAPI serves the admin REST API per CON-002 §4.
@@ -40,6 +52,8 @@ var namePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
 
 // NewAdminAPI creates a new admin API server.
 func NewAdminAPI(config AdminConfig, st *store.Store, jwtMgr *auth.JWTManager, tunnels *TunnelManager, sshSrv *SSHServer, logger *slog.Logger) *AdminAPI {
+	config = applyAdminTimeoutDefaults(config)
+
 	a := &AdminAPI{
 		config:    config,
 		store:     st,
@@ -109,11 +123,31 @@ func NewAdminAPI(config AdminConfig, st *store.Store, jwtMgr *auth.JWTManager, t
 	)))
 
 	a.server = &http.Server{
-		Addr:    config.Addr,
-		Handler: corsMiddleware(a.mux),
+		Addr:              config.Addr,
+		Handler:           corsMiddleware(a.mux),
+		ReadHeaderTimeout: config.ReadHeaderTimeout,
+		ReadTimeout:       config.ReadTimeout,
+		WriteTimeout:      config.WriteTimeout,
+		IdleTimeout:       config.IdleTimeout,
 	}
 
 	return a
+}
+
+func applyAdminTimeoutDefaults(config AdminConfig) AdminConfig {
+	if config.ReadHeaderTimeout == 0 {
+		config.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
+	}
+	if config.ReadTimeout == 0 {
+		config.ReadTimeout = defaultHTTPReadTimeout
+	}
+	if config.WriteTimeout == 0 {
+		config.WriteTimeout = defaultHTTPWriteTimeout
+	}
+	if config.IdleTimeout == 0 {
+		config.IdleTimeout = defaultHTTPIdleTimeout
+	}
+	return config
 }
 
 // Start begins serving the admin API.
@@ -396,8 +430,6 @@ func (a *AdminAPI) handleListTunnels(w http.ResponseWriter, r *http.Request) {
 	a.writeJSON(w, http.StatusOK, map[string]interface{}{"tunnels": items})
 }
 
-
-
 // handleMetrics returns aggregated metrics across all active tunnels.
 func (a *AdminAPI) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	active := a.tunnels.ListActive()
@@ -422,12 +454,12 @@ func (a *AdminAPI) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	uptime := time.Since(a.startTime).Seconds()
 
 	resp := struct {
-		TotalBytesIn       int64   `json:"total_bytes_in"`
-		TotalBytesOut      int64   `json:"total_bytes_out"`
-		TotalRequestsProxied int64 `json:"total_requests_proxied"`
-		ActiveTunnels      int     `json:"active_tunnels"`
-		ActiveClients      int     `json:"active_clients"`
-		UptimeSeconds      float64 `json:"uptime_seconds"`
+		TotalBytesIn         int64   `json:"total_bytes_in"`
+		TotalBytesOut        int64   `json:"total_bytes_out"`
+		TotalRequestsProxied int64   `json:"total_requests_proxied"`
+		ActiveTunnels        int     `json:"active_tunnels"`
+		ActiveClients        int     `json:"active_clients"`
+		UptimeSeconds        float64 `json:"uptime_seconds"`
 	}{
 		TotalBytesIn:         totalBytesIn,
 		TotalBytesOut:        totalBytesOut,

--- a/internal/server/edge.go
+++ b/internal/server/edge.go
@@ -45,6 +45,7 @@ type EdgeConfig struct {
 
 const (
 	defaultHTTPReadHeaderTimeout = 5 * time.Second
+	defaultHTTPReadTimeout       = 15 * time.Second
 	defaultHTTPWriteTimeout      = 30 * time.Second
 	defaultEdgeWriteTimeout      = 10 * time.Minute
 	defaultHTTPIdleTimeout       = 120 * time.Second

--- a/internal/server/edge.go
+++ b/internal/server/edge.go
@@ -33,7 +33,7 @@ type EdgeConfig struct {
 	// Default: 5s.
 	ReadHeaderTimeout time.Duration
 	// ReadTimeout limits how long the server spends reading the full request.
-	// Default: 15s.
+	// Default: 0 (disabled) for edge tunnel traffic so slow/large uploads are not cut off.
 	ReadTimeout time.Duration
 	// WriteTimeout limits response writes. Default: 10m for edge tunnel responses,
 	// which may be long-lived streams and should not use a short API timeout.
@@ -45,7 +45,6 @@ type EdgeConfig struct {
 
 const (
 	defaultHTTPReadHeaderTimeout = 5 * time.Second
-	defaultHTTPReadTimeout       = 15 * time.Second
 	defaultHTTPWriteTimeout      = 30 * time.Second
 	defaultEdgeWriteTimeout      = 10 * time.Minute
 	defaultHTTPIdleTimeout       = 120 * time.Second
@@ -96,9 +95,6 @@ func NewEdgeRouter(config EdgeConfig, tunnels *TunnelManager, logger *slog.Logge
 func applyEdgeTimeoutDefaults(config EdgeConfig) EdgeConfig {
 	if config.ReadHeaderTimeout == 0 {
 		config.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
-	}
-	if config.ReadTimeout == 0 {
-		config.ReadTimeout = defaultHTTPReadTimeout
 	}
 	if config.WriteTimeout == 0 {
 		// Use a deliberately long edge write timeout so slowloris-style writes are

--- a/internal/server/edge.go
+++ b/internal/server/edge.go
@@ -29,7 +29,27 @@ type EdgeConfig struct {
 	// ProxyTimeout is the maximum time to wait for a proxied response.
 	// Default: 30s.
 	ProxyTimeout time.Duration
+	// ReadHeaderTimeout limits how long the server spends reading request headers.
+	// Default: 5s.
+	ReadHeaderTimeout time.Duration
+	// ReadTimeout limits how long the server spends reading the full request.
+	// Default: 15s.
+	ReadTimeout time.Duration
+	// WriteTimeout limits response writes. Default: 10m for edge tunnel responses,
+	// which may be long-lived streams and should not use a short API timeout.
+	WriteTimeout time.Duration
+	// IdleTimeout limits how long keep-alive connections remain idle.
+	// Default: 120s.
+	IdleTimeout time.Duration
 }
+
+const (
+	defaultHTTPReadHeaderTimeout = 5 * time.Second
+	defaultHTTPReadTimeout       = 15 * time.Second
+	defaultHTTPWriteTimeout      = 30 * time.Second
+	defaultEdgeWriteTimeout      = 10 * time.Minute
+	defaultHTTPIdleTimeout       = 120 * time.Second
+)
 
 // EdgeRouter routes incoming public HTTP requests to the correct tunnel
 // by extracting the subdomain from the Host header and proxying the
@@ -40,9 +60,9 @@ type EdgeRouter struct {
 	logger            *slog.Logger
 	server            *http.Server
 	tlsMgr            *TLSManager
-	redirectSrv       *http.Server   // HTTP→HTTPS redirect server (when TLS enabled)
-	baseDomainHandler http.Handler   // fallback handler for apex/base domain (dashboard)
-	rateLimiter       *RateLimiter   // per-tunnel rate limiter
+	redirectSrv       *http.Server // HTTP→HTTPS redirect server (when TLS enabled)
+	baseDomainHandler http.Handler // fallback handler for apex/base domain (dashboard)
+	rateLimiter       *RateLimiter // per-tunnel rate limiter
 }
 
 // NewEdgeRouter creates a new HTTP edge router.
@@ -50,6 +70,7 @@ func NewEdgeRouter(config EdgeConfig, tunnels *TunnelManager, logger *slog.Logge
 	if config.ProxyTimeout == 0 {
 		config.ProxyTimeout = 30 * time.Second
 	}
+	config = applyEdgeTimeoutDefaults(config)
 
 	e := &EdgeRouter{
 		config:  config,
@@ -61,11 +82,44 @@ func NewEdgeRouter(config EdgeConfig, tunnels *TunnelManager, logger *slog.Logge
 	mux.HandleFunc("/", e.handleRequest)
 
 	e.server = &http.Server{
-		Addr:    config.Addr,
-		Handler: mux,
+		Addr:              config.Addr,
+		Handler:           mux,
+		ReadHeaderTimeout: config.ReadHeaderTimeout,
+		ReadTimeout:       config.ReadTimeout,
+		WriteTimeout:      config.WriteTimeout,
+		IdleTimeout:       config.IdleTimeout,
 	}
 
 	return e
+}
+
+func applyEdgeTimeoutDefaults(config EdgeConfig) EdgeConfig {
+	if config.ReadHeaderTimeout == 0 {
+		config.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
+	}
+	if config.ReadTimeout == 0 {
+		config.ReadTimeout = defaultHTTPReadTimeout
+	}
+	if config.WriteTimeout == 0 {
+		// Use a deliberately long edge write timeout so slowloris-style writes are
+		// bounded without cutting off normal tunnel streams as quickly as API calls.
+		config.WriteTimeout = defaultEdgeWriteTimeout
+	}
+	if config.IdleTimeout == 0 {
+		config.IdleTimeout = defaultHTTPIdleTimeout
+	}
+	return config
+}
+
+func (e *EdgeRouter) newRedirectServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: e.config.ReadHeaderTimeout,
+		ReadTimeout:       e.config.ReadTimeout,
+		WriteTimeout:      e.config.WriteTimeout,
+		IdleTimeout:       e.config.IdleTimeout,
+	}
 }
 
 // Start begins listening for HTTP requests on the configured address.
@@ -135,10 +189,7 @@ func (e *EdgeRouter) startTLS(ctx context.Context) error {
 		http.Redirect(w, r, target, http.StatusMovedPermanently)
 	}))
 
-	e.redirectSrv = &http.Server{
-		Addr:    redirectAddr,
-		Handler: redirectHandler,
-	}
+	e.redirectSrv = e.newRedirectServer(redirectAddr, redirectHandler)
 
 	redirectLn, err := net.Listen("tcp", redirectAddr)
 	if err != nil {

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestEdgeRouterConfiguresDefaultHTTPServerTimeouts(t *testing.T) {
+	edge := NewEdgeRouter(EdgeConfig{Addr: ":0"}, nil, slog.Default())
+
+	if edge.server.ReadHeaderTimeout != 5*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", edge.server.ReadHeaderTimeout, 5*time.Second)
+	}
+	if edge.server.ReadTimeout != 15*time.Second {
+		t.Fatalf("ReadTimeout = %v, want %v", edge.server.ReadTimeout, 15*time.Second)
+	}
+	if edge.server.IdleTimeout != 120*time.Second {
+		t.Fatalf("IdleTimeout = %v, want %v", edge.server.IdleTimeout, 120*time.Second)
+	}
+	if edge.server.WriteTimeout != 10*time.Minute {
+		t.Fatalf("WriteTimeout = %v, want %v", edge.server.WriteTimeout, 10*time.Minute)
+	}
+}
+
+func TestEdgeRouterUsesConfiguredHTTPServerTimeouts(t *testing.T) {
+	edge := NewEdgeRouter(EdgeConfig{
+		Addr:              ":0",
+		ReadHeaderTimeout: 2 * time.Second,
+		ReadTimeout:       3 * time.Second,
+		WriteTimeout:      4 * time.Second,
+		IdleTimeout:       5 * time.Second,
+	}, nil, slog.Default())
+
+	if edge.server.ReadHeaderTimeout != 2*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", edge.server.ReadHeaderTimeout, 2*time.Second)
+	}
+	if edge.server.ReadTimeout != 3*time.Second {
+		t.Fatalf("ReadTimeout = %v, want %v", edge.server.ReadTimeout, 3*time.Second)
+	}
+	if edge.server.WriteTimeout != 4*time.Second {
+		t.Fatalf("WriteTimeout = %v, want %v", edge.server.WriteTimeout, 4*time.Second)
+	}
+	if edge.server.IdleTimeout != 5*time.Second {
+		t.Fatalf("IdleTimeout = %v, want %v", edge.server.IdleTimeout, 5*time.Second)
+	}
+}
+
+func TestEdgeRedirectServerUsesEdgeTimeouts(t *testing.T) {
+	edge := NewEdgeRouter(EdgeConfig{
+		Addr:              ":0",
+		ReadHeaderTimeout: 2 * time.Second,
+		ReadTimeout:       3 * time.Second,
+		WriteTimeout:      4 * time.Second,
+		IdleTimeout:       5 * time.Second,
+	}, nil, slog.Default())
+
+	redirectServer := edge.newRedirectServer(":0", nil)
+	if redirectServer.ReadHeaderTimeout != 2*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", redirectServer.ReadHeaderTimeout, 2*time.Second)
+	}
+	if redirectServer.ReadTimeout != 3*time.Second {
+		t.Fatalf("ReadTimeout = %v, want %v", redirectServer.ReadTimeout, 3*time.Second)
+	}
+	if redirectServer.WriteTimeout != 4*time.Second {
+		t.Fatalf("WriteTimeout = %v, want %v", redirectServer.WriteTimeout, 4*time.Second)
+	}
+	if redirectServer.IdleTimeout != 5*time.Second {
+		t.Fatalf("IdleTimeout = %v, want %v", redirectServer.IdleTimeout, 5*time.Second)
+	}
+}
+
+func TestAdminAPIConfiguresDefaultHTTPServerTimeouts(t *testing.T) {
+	admin := NewAdminAPI(AdminConfig{Addr: ":0"}, nil, nil, nil, nil, slog.Default())
+
+	if admin.server.ReadHeaderTimeout != 5*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", admin.server.ReadHeaderTimeout, 5*time.Second)
+	}
+	if admin.server.ReadTimeout != 15*time.Second {
+		t.Fatalf("ReadTimeout = %v, want %v", admin.server.ReadTimeout, 15*time.Second)
+	}
+	if admin.server.WriteTimeout != 30*time.Second {
+		t.Fatalf("WriteTimeout = %v, want %v", admin.server.WriteTimeout, 30*time.Second)
+	}
+	if admin.server.IdleTimeout != 120*time.Second {
+		t.Fatalf("IdleTimeout = %v, want %v", admin.server.IdleTimeout, 120*time.Second)
+	}
+}
+
+func TestAdminAPIUsesConfiguredHTTPServerTimeouts(t *testing.T) {
+	admin := NewAdminAPI(AdminConfig{
+		Addr:              ":0",
+		ReadHeaderTimeout: 2 * time.Second,
+		ReadTimeout:       3 * time.Second,
+		WriteTimeout:      4 * time.Second,
+		IdleTimeout:       5 * time.Second,
+	}, nil, nil, nil, nil, slog.Default())
+
+	if admin.server.ReadHeaderTimeout != 2*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", admin.server.ReadHeaderTimeout, 2*time.Second)
+	}
+	if admin.server.ReadTimeout != 3*time.Second {
+		t.Fatalf("ReadTimeout = %v, want %v", admin.server.ReadTimeout, 3*time.Second)
+	}
+	if admin.server.WriteTimeout != 4*time.Second {
+		t.Fatalf("WriteTimeout = %v, want %v", admin.server.WriteTimeout, 4*time.Second)
+	}
+	if admin.server.IdleTimeout != 5*time.Second {
+		t.Fatalf("IdleTimeout = %v, want %v", admin.server.IdleTimeout, 5*time.Second)
+	}
+}

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -12,8 +12,8 @@ func TestEdgeRouterConfiguresDefaultHTTPServerTimeouts(t *testing.T) {
 	if edge.server.ReadHeaderTimeout != 5*time.Second {
 		t.Fatalf("ReadHeaderTimeout = %v, want %v", edge.server.ReadHeaderTimeout, 5*time.Second)
 	}
-	if edge.server.ReadTimeout != 15*time.Second {
-		t.Fatalf("ReadTimeout = %v, want %v", edge.server.ReadTimeout, 15*time.Second)
+	if edge.server.ReadTimeout != 0 {
+		t.Fatalf("ReadTimeout = %v, want disabled timeout", edge.server.ReadTimeout)
 	}
 	if edge.server.IdleTimeout != 120*time.Second {
 		t.Fatalf("IdleTimeout = %v, want %v", edge.server.IdleTimeout, 120*time.Second)


### PR DESCRIPTION
Fixes #7

## Summary
- add timeout coverage for edge/admin HTTP servers
- configure read-header/read/write/idle timeouts with conservative defaults
- keep edge write timeout longer than admin to avoid prematurely cutting off tunnel responses

## Test plan
- go test ./internal/server -run 'Timeout|Edge|Admin' -v\n- go test ./internal/server -v