### PR TITLE
fix(client): readiness reconnect lifecycle

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/fonzygrok/fonzygrok/internal/client"
 	"github.com/fonzygrok/fonzygrok/internal/config"
@@ -194,8 +195,26 @@ func runTunnel(parent context.Context, serverAddr, token string, port int, insec
 
 	// ConnectWithRetry handles the full lifecycle:
 	// connect → open control → request tunnel → proxy → reconnect on failure.
-	err := connector.ConnectWithRetry(ctx, func() error {
-		return onConnect(ctx, connector, port, name, protocol, inspector, inspectDisplay, display, logger)
+	retryStatusShown := false
+	err := connector.ConnectWithRetryHooks(ctx, client.ConnectHooks{
+		OnConnectionFailed: func(err error, attempt int, backoff time.Duration) {
+			display.ConnectionFailed(err, attempt, int(backoff.Seconds()))
+			retryStatusShown = true
+		},
+		OnDisconnected: func(err error, backoff time.Duration) {
+			display.Disconnected()
+			retryStatusShown = false
+		},
+		OnRetrying: func(backoff time.Duration) {
+			if retryStatusShown {
+				retryStatusShown = false
+				return
+			}
+			display.Retrying(int(backoff.Seconds()))
+		},
+		OnConnected: func(connCtx context.Context) error {
+			return onConnect(connCtx, connector, port, name, protocol, inspector, inspectDisplay, display, logger)
+		},
 	})
 
 	if err != nil && err != context.Canceled {
@@ -263,16 +282,17 @@ func onConnect(ctx context.Context, connector *client.Connector, port int, name 
 	go proxy.HandleChannels(ctx, sshClient.HandleChannelOpen(client.ChannelTypeProxy))
 	go proxy.HandleChannels(ctx, sshClient.HandleChannelOpen(client.ChannelTypeTCPProxy))
 
-	// Block until context is done (signal or disconnect detected by caller).
-	<-ctx.Done()
+	go func() {
+		<-ctx.Done()
 
-	logger.Info("shutting down tunnel",
-		slog.String("tunnel_id", assignment.TunnelID),
-	)
+		logger.Info("shutting down tunnel",
+			slog.String("tunnel_id", assignment.TunnelID),
+		)
 
-	// Best-effort close tunnel on the control channel.
-	cc.CloseTunnel(assignment.TunnelID)
-	cc.Close()
+		// Best-effort close tunnel on the control channel.
+		cc.CloseTunnel(assignment.TunnelID)
+		cc.Close()
+	}()
 
 	return nil
 }

--- a/internal/client/display.go
+++ b/internal/client/display.go
@@ -97,6 +97,11 @@ func (d *Display) Disconnected() {
 	fmt.Fprintf(d.w, "  %s\n", d.yellow("⚠ Disconnected from server"))
 }
 
+// Retrying prints a yellow retry status message.
+func (d *Display) Retrying(backoffSec int) {
+	fmt.Fprintf(d.w, "  %s\n", d.yellow(fmt.Sprintf("↻ Retrying in %ds...", backoffSec)))
+}
+
 // Shutdown prints the shutdown message.
 func (d *Display) Shutdown() {
 	fmt.Fprintf(d.w, "  fonzygrok stopped.\n")

--- a/internal/client/display_test.go
+++ b/internal/client/display_test.go
@@ -106,6 +106,18 @@ func TestDisplayDisconnected(t *testing.T) {
 	}
 }
 
+// TestDisplayRetrying verifies retry status output.
+func TestDisplayRetrying(t *testing.T) {
+	var buf bytes.Buffer
+	d := NewDisplayNoColor(&buf)
+	d.Retrying(5)
+
+	got := buf.String()
+	if !strings.Contains(got, "Retrying in 5s...") {
+		t.Errorf("Retrying = %q, should contain retry delay", got)
+	}
+}
+
 // TestDisplayShutdown verifies shutdown message.
 func TestDisplayShutdown(t *testing.T) {
 	var buf bytes.Buffer

--- a/internal/client/reconnect.go
+++ b/internal/client/reconnect.go
@@ -17,6 +17,19 @@ const (
 	BackoffMultiplier = 2.0
 )
 
+// ConnectHooks receives lifecycle notifications from ConnectWithRetryHooks.
+// OnConnected is passed a per-connection context that is cancelled when that
+// specific SSH connection is lost or when the parent context is cancelled.
+// OnConnected should perform setup and return promptly; if it blocks,
+// ConnectWithRetryHooks still monitors the connection and reconnects on loss.
+type ConnectHooks struct {
+	OnConnecting       func(attempt int)
+	OnConnectionFailed func(err error, attempt int, backoff time.Duration)
+	OnRetrying         func(backoff time.Duration)
+	OnConnected        func(connCtx context.Context) error
+	OnDisconnected     func(err error, backoff time.Duration)
+}
+
 // ConnectWithRetry attempts to connect to the server, retrying with
 // exponential backoff (1s, 2s, 4s, 8s, 16s, 30s, 30s...) until
 // the context is cancelled. On success the backoff resets.
@@ -26,11 +39,28 @@ const (
 //
 // ConnectWithRetry blocks until the context is cancelled.
 func (c *Connector) ConnectWithRetry(ctx context.Context, onConnect func() error) error {
+	return c.ConnectWithRetryHooks(ctx, ConnectHooks{
+		OnConnected: func(context.Context) error {
+			if onConnect == nil {
+				return nil
+			}
+			return onConnect()
+		},
+	})
+}
+
+// ConnectWithRetryHooks attempts to connect to the server and owns the full
+// per-connection lifecycle: connect, setup callback, connection monitoring,
+// disconnect notification, cleanup, and retry.
+func (c *Connector) ConnectWithRetryHooks(ctx context.Context, hooks ConnectHooks) error {
 	backoff := InitialBackoff
 	attempt := 0
 
 	for {
 		attempt++
+		if hooks.OnConnecting != nil {
+			hooks.OnConnecting(attempt)
+		}
 
 		// Try to connect.
 		err := c.Connect(ctx)
@@ -40,7 +70,12 @@ func (c *Connector) ConnectWithRetry(ctx context.Context, onConnect func() error
 				slog.Int64("backoff_ms", backoff.Milliseconds()),
 				slog.String("error", err.Error()),
 			)
-
+			if hooks.OnConnectionFailed != nil {
+				hooks.OnConnectionFailed(err, attempt, backoff)
+			}
+			if hooks.OnRetrying != nil {
+				hooks.OnRetrying(backoff)
+			}
 			if sleepErr := c.sleepWithContext(ctx, backoff); sleepErr != nil {
 				return sleepErr // context cancelled
 			}
@@ -48,25 +83,54 @@ func (c *Connector) ConnectWithRetry(ctx context.Context, onConnect func() error
 			continue
 		}
 
-		// Connection succeeded — reset backoff.
+		// Connection succeeded — reset backoff for future disconnect retries.
 		backoff = InitialBackoff
 		attempt = 0
 
 		c.logger.Info("connected, running onConnect callback")
 
-		// Run the post-connect callback (e.g., open control channel, register tunnels).
-		if onConnect != nil {
-			if cbErr := onConnect(); cbErr != nil {
+		connCtx, cancelConn := context.WithCancel(ctx)
+		setupErr := make(chan error, 1)
+		if hooks.OnConnected != nil {
+			go func() { setupErr <- hooks.OnConnected(connCtx) }()
+		} else {
+			setupErr <- nil
+		}
+
+		disconnected := make(chan struct{})
+		go func() {
+			c.waitForDisconnect(connCtx)
+			close(disconnected)
+		}()
+
+		select {
+		case cbErr := <-setupErr:
+			if cbErr != nil {
 				c.logger.Warn("onConnect callback failed",
 					slog.String("error", cbErr.Error()),
 				)
+				cancelConn()
 				c.Close()
+				if hooks.OnConnectionFailed != nil {
+					hooks.OnConnectionFailed(cbErr, 1, backoff)
+				}
+				if hooks.OnRetrying != nil {
+					hooks.OnRetrying(backoff)
+				}
+				if sleepErr := c.sleepWithContext(ctx, backoff); sleepErr != nil {
+					return sleepErr
+				}
+				backoff = nextBackoff(backoff)
 				continue
 			}
+			// Setup completed. Continue monitoring until disconnect or cancellation.
+			<-disconnected
+		case <-disconnected:
+			// Setup may still be running; cancel its per-connection context and let
+			// lifecycle proceed so reconnect is not blocked by a long-lived callback.
 		}
 
-		// Wait for disconnection.
-		c.waitForDisconnect(ctx)
+		cancelConn()
 
 		// If context was cancelled, exit cleanly.
 		if ctx.Err() != nil {
@@ -79,6 +143,12 @@ func (c *Connector) ConnectWithRetry(ctx context.Context, onConnect func() error
 			slog.Int64("backoff_ms", backoff.Milliseconds()),
 		)
 		c.Close()
+		if hooks.OnDisconnected != nil {
+			hooks.OnDisconnected(nil, backoff)
+		}
+		if hooks.OnRetrying != nil {
+			hooks.OnRetrying(backoff)
+		}
 
 		if sleepErr := c.sleepWithContext(ctx, backoff); sleepErr != nil {
 			return sleepErr

--- a/internal/client/reconnect_test.go
+++ b/internal/client/reconnect_test.go
@@ -175,6 +175,120 @@ func TestConnectWithRetryReconnect(t *testing.T) {
 	}
 }
 
+// TestConnectWithRetryLifecycleCallbacksReportFailuresAndRetries verifies that
+// clients can surface connection failure and retry lifecycle events.
+func TestConnectWithRetryLifecycleCallbacksReportFailuresAndRetries(t *testing.T) {
+	c := NewConnector(ClientConfig{
+		ServerAddr: "127.0.0.1:1",
+		Token:      testToken,
+		Insecure:   true,
+	}, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	failed := make(chan time.Duration, 1)
+	retrying := make(chan time.Duration, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.ConnectWithRetryHooks(ctx, ConnectHooks{
+			OnConnectionFailed: func(err error, attempt int, backoff time.Duration) {
+				if attempt != 1 {
+					t.Errorf("attempt = %d, want 1", attempt)
+				}
+				failed <- backoff
+			},
+			OnRetrying: func(backoff time.Duration) {
+				retrying <- backoff
+			},
+		})
+	}()
+
+	select {
+	case got := <-failed:
+		if got != InitialBackoff {
+			t.Fatalf("OnConnectionFailed backoff = %v, want %v", got, InitialBackoff)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OnConnectionFailed")
+	}
+
+	select {
+	case got := <-retrying:
+		if got != InitialBackoff {
+			t.Fatalf("OnRetrying backoff = %v, want %v", got, InitialBackoff)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OnRetrying")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ConnectWithRetryHooks did not exit after cancel")
+	}
+}
+
+func TestConnectWithRetryMonitorsConnectionWhenOnConnectedBlocks(t *testing.T) {
+	addr, cleanup := startTestSSHServer(t, testToken)
+
+	c := NewConnector(ClientConfig{
+		ServerAddr: addr,
+		Token:      testToken,
+		Insecure:   true,
+	}, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	connected := make(chan struct{})
+	disconnected := make(chan struct{})
+	releaseOnConnected := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.ConnectWithRetryHooks(ctx, ConnectHooks{
+			OnConnected: func(connCtx context.Context) error {
+				close(connected)
+				<-releaseOnConnected
+				return nil
+			},
+			OnDisconnected: func(err error, backoff time.Duration) {
+				close(disconnected)
+				cancel()
+			},
+		})
+	}()
+
+	select {
+	case <-connected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial connection")
+	}
+
+	cleanup()
+
+	select {
+	case <-disconnected:
+	case <-time.After(10 * time.Second):
+		close(releaseOnConnected)
+		t.Fatal("disconnect was not observed while OnConnected was blocked")
+	}
+
+	close(releaseOnConnected)
+	select {
+	case err := <-errCh:
+		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ConnectWithRetryHooks did not exit")
+	}
+}
+
 // TestConnectWithRetryCallbackError verifies that a failing onConnect
 // callback causes a retry.
 func TestConnectWithRetryCallbackError(t *testing.T) {


### PR DESCRIPTION
Fixes #1
Fixes #2
Fixes #3

## Summary
- move client reconnect ownership into ConnectWithRetryHooks with per-connection contexts
- keep onConnect setup non-blocking so disconnect monitoring can reconnect
- add lifecycle callbacks and user-facing disconnected/retry status
- keep tunnel setup based on control-plane assignment without probing local app availability

## Tests
- go test ./cmd/client ./internal/client -v
- go test $(go list ./... | grep -v '/internal/store$')