### PR TITLE
docs: update infrastructure docs for PostgreSQL deployment

### DIFF
--- a/CODEX/00_INDEX/MANIFEST.yaml
+++ b/CODEX/00_INDEX/MANIFEST.yaml
@@ -536,9 +536,10 @@ documents:
     tags: [governance, infrastructure, operations, deployment, docker]
     agents: [all]
     summary: >
-      Fonzygrok infrastructure decisions: Docker Compose on single VPS,
-      SQLite embedded database, Go single-binary builds, port assignments,
-      security model, adaptation table from architecture assumptions.
+      Fonzygrok infrastructure decisions: Docker Compose on single VPS/EC2,
+      PostgreSQL 16 in Docker Compose, Alpine runtime application image,
+      GitHub Actions tag-triggered release/deploy, port assignments,
+      security model, and backup/restore operations.
 
   # ── 20_BLUEPRINTS ──────────────────────────────────────────────────────────
   - id: BLU-001
@@ -624,8 +625,8 @@ documents:
     agents: [architect]
     summary: >
       Step-by-step production deployment runbook for fonzygrok on Ubuntu EC2
-      with Docker Compose. Covers setup, configuration, deployment, and
-      post-deployment verification.
+      with Docker Compose, PostgreSQL, tag-triggered GitHub Actions release/deploy,
+      first-time host bootstrap, operational commands, and post-deployment verification.
   # ── 40_VERIFICATION ────────────────────────────────────────────────────────
   # (empty — add project-specific verification docs here)
 

--- a/CODEX/10_GOVERNANCE/GOV-008_InfrastructureAndOperations.md
+++ b/CODEX/10_GOVERNANCE/GOV-008_InfrastructureAndOperations.md
@@ -48,13 +48,21 @@ version: 2.0.0
 ### 2.1 Backup / Restore Commands
 
 ```bash
+# Load configured DB identity from the Compose env file when present.
+cd ~/fonzygrok/docker
+set -a
+[ -f .env ] && . ./.env
+set +a
+DB_USER="${POSTGRES_USER:-fonzygrok}"
+DB_NAME="${POSTGRES_DB:-fonzygrok}"
+
 # Backup
-docker exec fonzygrok-postgres pg_dump -U fonzygrok fonzygrok \
-  > fonzygrok_backup_$(date +%Y%m%d).sql
+docker exec fonzygrok-postgres pg_dump -U "$DB_USER" "$DB_NAME" \
+  > "fonzygrok_backup_$(date +%Y%m%d).sql"
 
 # Restore
 cat fonzygrok_backup_YYYYMMDD.sql | \
-  docker exec -i fonzygrok-postgres psql -U fonzygrok fonzygrok
+  docker exec -i fonzygrok-postgres psql -U "$DB_USER" "$DB_NAME"
 ```
 
 ---

--- a/CODEX/10_GOVERNANCE/GOV-008_InfrastructureAndOperations.md
+++ b/CODEX/10_GOVERNANCE/GOV-008_InfrastructureAndOperations.md
@@ -6,13 +6,13 @@ status: APPROVED
 owner: architect
 agents: [all]
 tags: [governance, infrastructure, operations, deployment, docker]
-related: [PRJ-001, GOV-007, RES-001]
+related: [PRJ-001, GOV-007, RES-001, RUN-001]
 created: 2026-03-31
-updated: 2026-03-31
-version: 1.0.0
+updated: 2026-04-24
+version: 2.0.0
 ---
 
-> **BLUF:** Fonzygrok deploys as a Docker container on a single Linux VPS. SQLite is the database (embedded, single-file). Both server and client are static Go binaries cross-compiled via `goreleaser`. No managed cloud services. No Kubernetes. No multi-node. This doc overrides any BLU- assumptions that conflict.
+> **BLUF:** Fonzygrok production runs on a single Ubuntu EC2/VPS host using Docker Compose. The application container runs the Go server binary on Alpine, and PostgreSQL 16 runs as a companion Compose service with a persistent Docker volume. GitHub Actions builds release artifacts and deploys production on `v*` tag pushes after required human release approval. No Kubernetes, managed database, CDN, or multi-node orchestration is used.
 
 # Infrastructure and Operations
 
@@ -22,13 +22,14 @@ version: 1.0.0
 
 | Property | Decision |
 |:---------|:---------|
-| **Server deployment** | Docker Compose on a single Linux VPS |
-| **Client deployment** | Direct binary download (user's machine) |
-| **Container base** | `gcr.io/distroless/static-debian12` (minimal, no shell) |
-| **Orchestration** | Docker Compose (single-node, no Kubernetes) |
-| **Reverse proxy** | Not needed — fonzygrok server IS the edge |
-| **TLS termination** | Built-in (autocert / Let's Encrypt) in v1.1. Self-signed or no TLS in v1.0. |
-| **DNS** | Wildcard A record `*.tunnel.example.com` → VPS IP (v1.1+). Direct IP in v1.0. |
+| **Server deployment** | Docker Compose on one Ubuntu EC2/VPS host |
+| **Application container** | `docker/Dockerfile.prod`, Alpine runtime, non-root `fonzygrok` user |
+| **Database container** | `postgres:16-alpine` service in `docker/docker-compose.yml` |
+| **Client deployment** | GitHub Release binary download / install scripts |
+| **Orchestration** | Docker Compose only; no Kubernetes |
+| **Reverse proxy** | Not required; `fonzygrok-server` is the HTTP/HTTPS edge |
+| **TLS termination** | Built-in autocert / Let's Encrypt when `TLS_ENABLED=true` |
+| **DNS** | Apex and wildcard records point at the host: `fonzygrok.com`, `*.fonzygrok.com` or deployment-specific equivalent |
 
 ---
 
@@ -36,11 +37,25 @@ version: 1.0.0
 
 | Property | Decision |
 |:---------|:---------|
-| **Engine** | SQLite via `modernc.org/sqlite` (pure Go, CGo-free) |
-| **Location** | `/data/fonzygrok.db` inside container, mounted as Docker volume |
-| **Backup** | File-level copy of the `.db` file. VACUUM periodically. |
-| **Migration** | Embedded SQL migrations executed on startup |
-| **Concurrency** | WAL mode. Single-writer is acceptable for v1 scale. |
+| **Engine** | PostgreSQL 16 (`postgres:16-alpine`) |
+| **Production location** | Docker named volume `fonzygrok-pgdata` mounted at `/var/lib/postgresql/data` |
+| **Application connection** | `DATABASE_URL` constructed in Compose from `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` |
+| **Migration** | Embedded SQL migrations executed by the server on startup |
+| **Backup** | `pg_dump` from the PostgreSQL container to a dated `.sql` file |
+| **Restore** | Pipe backup into `psql` inside the PostgreSQL container |
+| **Developer tests** | `TEST_DATABASE_URL` may be set by developers/CI for test databases; local PostgreSQL setup is outside this governance doc |
+
+### 2.1 Backup / Restore Commands
+
+```bash
+# Backup
+docker exec fonzygrok-postgres pg_dump -U fonzygrok fonzygrok \
+  > fonzygrok_backup_$(date +%Y%m%d).sql
+
+# Restore
+cat fonzygrok_backup_YYYYMMDD.sql | \
+  docker exec -i fonzygrok-postgres psql -U fonzygrok fonzygrok
+```
 
 ---
 
@@ -48,47 +63,57 @@ version: 1.0.0
 
 | Port | Protocol | Purpose |
 |:-----|:---------|:--------|
-| `2222` | TCP (SSH) | Client tunnel connections (control + data plane) |
-| `8080` | HTTP | Public-facing edge (proxied HTTP requests) |
-| `8443` | HTTPS | Public-facing edge with TLS (v1.1+) |
-| `9090` | HTTP | Admin API (internal, not exposed publicly) |
+| `2222` | TCP (SSH) | Client tunnel connections/control channel |
+| `80` | HTTP | HTTP redirect and ACME HTTP-01 challenge handling |
+| `443` | HTTPS | Public edge for tunnels, dashboard, and install scripts |
+| `8080` | HTTP | Non-TLS HTTP edge fallback / internal mapping |
+| `9090` | HTTP | Admin API and health checks; optional external mapping, prefer internal access only |
+| `40000-40100` | TCP | TCP tunnel public port range |
 
 ### 3.1 Docker Compose Port Mapping
 
 ```yaml
 ports:
-  - "2222:2222"   # SSH tunnel endpoint
-  - "80:8080"     # Public HTTP edge
-  - "443:8443"    # Public HTTPS edge (v1.1)
-  - "9090:9090"   # Admin API (bind to localhost in production)
+  - "${SSH_PORT:-2222}:2222"
+  - "80:80"
+  - "8080:8080"
+  - "${HTTPS_PORT:-443}:443"
+  - "${TCP_PORT_RANGE:-40000-40100}:40000-40100"
+  # Optional direct admin API exposure only:
+  # - "${ADMIN_PORT:-9090}:9090"
 ```
 
 ---
 
-## 4. Build & Release
+## 4. Build, Release, and Deploy
 
 | Property | Decision |
 |:---------|:---------|
-| **Build system** | `Makefile` + `goreleaser` |
-| **Targets** | `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64` |
-| **Artifacts** | Two binaries: `fonzygrok-server`, `fonzygrok` (client) |
-| **Docker image** | Built from multi-stage Dockerfile (build → distroless) |
-| **Versioning** | Semantic Versioning. Git tags trigger releases. |
+| **Build system** | GitHub Actions release workflow plus Go toolchain |
+| **Release trigger** | Push a SemVer-style `v*` tag after human approval per GOV-007 |
+| **Artifacts** | Server and client binaries for Linux, macOS, and Windows plus checksums |
+| **Docker image** | Runtime-only Alpine image that copies pre-built Linux binaries from `bin/` |
+| **Deploy mechanism** | GitHub Actions SSHes to production, checks out the release tag, copies binaries, and runs Docker Compose |
+| **Production deploy command** | Workflow executes `docker compose down || true && docker compose up -d --build` on the host |
+
+> **Release control:** Production deployment remains tag-triggered. Branch pushes and PR merges must not deploy production unless the release workflow is explicitly changed by an approved infrastructure track.
 
 ---
 
 ## 5. Adaptation Table
 
-> Per GOV-007 §9.7: When architecture documents assume capabilities that differ from actual deployment, document the adaptation here.
+> Per GOV-007 §9.7: when architecture documents assume capabilities that differ from actual deployment, document the adaptation here.
 
-| BLU- Assumption | Actual Deployment | Adaptation |
-|:----------------|:------------------|:-----------|
-| Managed database service | Self-managed SQLite in container | Mount `/data` as Docker volume for persistence |
-| Load balancer / CDN | No load balancer | Server binds directly to ports 80/443 |
-| Auto-scaling | Single instance | Vertical scaling only (bigger VPS) |
-| DNS management API | Manual DNS setup | Human configures wildcard DNS record |
-| Secret management service | Environment variables | `.env` file mounted into container, gitignored |
-| CI/CD pipeline | Manual build + deploy | `make docker-push` + `docker compose pull && docker compose up -d` |
+| Prior Assumption | Actual Deployment | Adaptation |
+|:-----------------|:------------------|:-----------|
+| Prior embedded database assumption | PostgreSQL container | Persist `fonzygrok-pgdata`; use `pg_dump`/`psql` for backup and restore |
+| Managed database service | Self-managed PostgreSQL in Docker Compose | Secure credentials in `.env` / GitHub secrets; monitor container health |
+| Prior multi-stage/minimal app image assumption | Runtime-only Alpine image | GitHub Actions pre-builds binaries; Dockerfile copies them into Alpine |
+| Manual release artifacts | GitHub Actions release workflow | `v*` tags build binaries, checksums, and GitHub Release assets |
+| Manual deploy only | Tag-triggered GitHub Actions deploy | Workflow SSHes to host and restarts Compose after release build |
+| Load balancer / CDN | No load balancer | Server binds directly to host ports 80/443/2222 and TCP range |
+| DNS management API | Manual DNS setup | Human configures apex and wildcard DNS records |
+| Secret management service | GitHub Actions secrets + host `.env` | Never commit secrets; restrict `.env` file permissions |
 
 ---
 
@@ -96,32 +121,34 @@ ports:
 
 | Concern | Mitigation |
 |:--------|:-----------|
-| SSH brute force | Token auth only (no password). Rate-limit connection attempts. |
-| Admin API exposure | Bind `:9090` to `127.0.0.1` only. Access via SSH tunnel to VPS. |
-| Container privileges | Run as non-root user inside distroless container |
-| SQLite file access | Volume permissions restricted to container user |
-| Secrets in env | `.env` file with `600` permissions. Never committed to git. |
+| SSH brute force | Token auth only; rate-limit connection attempts |
+| Admin API exposure | Keep port `9090` internal by default; access from host or trusted SSH session |
+| Container privileges | Run application container as non-root user |
+| PostgreSQL credential exposure | Use non-default `POSTGRES_PASSWORD`; store in `.env`/secrets only |
+| PostgreSQL persistence | Restrict host and Docker volume access to trusted operators |
+| TLS private material | Persist cert cache in `fonzygrok-certs`; do not copy cert material into git |
+| CI/CD deploy key | Store deploy SSH key only in GitHub Actions secrets |
 
 ---
 
-## 7. Monitoring
+## 7. Monitoring and Operations
 
 | Tool | Purpose | Priority |
 |:-----|:--------|:---------|
-| Structured logs (`slog`) | Application logging to stdout (Docker captures) | v1.0 |
-| Health check endpoint | `GET /healthz` on admin API | v1.0 |
-| `docker compose logs -f` | Log tailing | v1.0 |
-| Prometheus metrics | Connection counts, latency histograms | v1.2 |
+| GitHub Actions logs | Build, release, and deploy audit trail | v1.2+ |
+| Docker health checks | PostgreSQL and server health in Compose | v1.2+ |
+| Admin health endpoint | `GET /api/v1/health` on `localhost:9090` from host/container | v1.0+ |
+| Structured logs (`slog`) | Application logs to stdout captured by Docker | v1.0+ |
+| `docker compose logs -f` | Live operational log tailing | v1.0+ |
+| PostgreSQL backup files | Point-in-time logical backups | v1.2+ |
 
 ---
 
-## 8. Operational Runbooks (TODO)
+## 8. Operational Runbooks
 
-| Runbook | Topics | Sprint |
-|:--------|:-------|:-------|
-| `RUN-FG-001` | Fresh VPS setup, Docker install, domain/DNS, first deploy | SPR-007 |
-| `RUN-FG-002` | Upgrade deployment (pull new image, restart) | SPR-007 |
-| `RUN-FG-003` | Backup and restore SQLite database | SPR-007 |
+| Runbook | Topics |
+|:--------|:-------|
+| `RUN-001` | Production deployment, tag-triggered release/deploy, verification, PostgreSQL backup/restore |
 
 ---
 
@@ -129,4 +156,5 @@ ports:
 
 | Date | Version | Change | Author |
 |:-----|:--------|:-------|:-------|
+| 2026-04-24 | 2.0.0 | Updated infrastructure standard for PostgreSQL, Alpine Docker runtime, GitHub Actions tag-triggered release/deploy, and PostgreSQL backup/restore | Hermes Agent |
 | 2026-03-31 | 1.0.0 | Initial infrastructure decisions | Architect + Human |

--- a/CODEX/30_RUNBOOKS/RUN-001_Production_Deployment.md
+++ b/CODEX/30_RUNBOOKS/RUN-001_Production_Deployment.md
@@ -629,6 +629,7 @@ Production deployment is tag-triggered through `.github/workflows/release.yml`. 
 2. Create and push an approved SemVer tag, for example:
 
 ```bash
+cd ~/fonzygrok
 git checkout main
 git pull origin main
 git tag vX.Y.Z

--- a/CODEX/30_RUNBOOKS/RUN-001_Production_Deployment.md
+++ b/CODEX/30_RUNBOOKS/RUN-001_Production_Deployment.md
@@ -8,8 +8,8 @@ agents: [architect]
 tags: [deployment, docker, production, runbook]
 related: [GOV-008, BLU-001]
 created: 2026-03-31
-updated: 2026-04-07
-version: 4.0.0
+updated: 2026-04-24
+version: 5.0.0
 ---
 
 # Production Deployment: fonzygrok on Ubuntu EC2 + Docker
@@ -174,7 +174,9 @@ POSTGRES_DB=fonzygrok
 
 Save and exit nano: `Ctrl+O`, `Enter`, `Ctrl+X`.
 
-### 3.5 Build and start
+### 3.5 First-time manual start
+
+Production releases are normally deployed by GitHub Actions when a human-approved `v*` tag is pushed. Use this manual Compose start only for first-time host bootstrap or emergency operator-driven recovery after the release workflow has placed Linux binaries in `~/fonzygrok/bin`.
 
 ```bash
 cd ~/fonzygrok/docker
@@ -184,9 +186,9 @@ docker compose up -d --build
 This will:
 1. Pull `postgres:16-alpine` (first run only)
 2. Start PostgreSQL with a persistent named volume (`fonzygrok-pgdata`)
-3. Wait for PG health check to pass
-4. Build the fonzygrok server image from pre-built binaries (Dockerfile.prod)
-5. Run migrations automatically on startup
+3. Wait for the PostgreSQL health check to pass
+4. Build the Alpine runtime image from pre-built binaries (`Dockerfile.prod`)
+5. Run migrations automatically on server startup
 
 Wait for it to finish. Then verify:
 
@@ -620,11 +622,33 @@ cd ~/fonzygrok/docker && docker compose down
 ```
 
 ### Update to a new version
+
+Production deployment is tag-triggered through `.github/workflows/release.yml`. Do **not** deploy production from a branch push or by pulling `main` directly as the normal release path.
+
+1. Complete review and required human release approval.
+2. Create and push an approved SemVer tag, for example:
+
 ```bash
-cd ~/fonzygrok
+git checkout main
 git pull origin main
-cd docker
-docker compose up -d --build
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+3. GitHub Actions will:
+   - Run tests against PostgreSQL using `TEST_DATABASE_URL`.
+   - Build release binaries and checksums.
+   - Create/update the GitHub Release.
+   - SSH to production, check out the tag, copy pre-built Linux binaries into `~/fonzygrok/bin`, and run `docker compose down || true && docker compose up -d --build`.
+
+4. Monitor the Actions run and complete the post-deployment verification checklist below.
+
+### Emergency manual restart after binaries are present
+
+Use only if the host already has the intended release code and binaries:
+
+```bash
+cd ~/fonzygrok/docker && docker compose up -d --build
 ```
 
 ### List tokens

--- a/README.md
+++ b/README.md
@@ -273,9 +273,10 @@ The server includes a web dashboard at the apex domain (e.g., `https://fonzygrok
 - **A server** (VPS, EC2, etc.) with ports open:
   - `2222` — SSH tunnel connections
   - `80` / `443` — Public HTTP/HTTPS traffic
-  - `9090` — Admin API (bind to localhost or private network)
   - `40000-40100` — TCP tunnel port range (optional)
+  - `9090` — Admin API only if you intentionally expose it; by default keep it internal and use host/container access
 - **Docker** and **Docker Compose**
+- **PostgreSQL via Docker Compose** (the bundled Compose file starts `postgres:16-alpine` with a persistent named volume)
 
 ### Docker Deployment
 
@@ -292,16 +293,22 @@ Edit `.env`:
 DOMAIN=yourdomain.com
 TLS_ENABLED=true
 SSH_PORT=2222
-HTTP_PORT=80
 HTTPS_PORT=443
-ADMIN_PORT=9090
+POSTGRES_USER=fonzygrok
+POSTGRES_PASSWORD=change-me-to-a-long-random-value
+POSTGRES_DB=fonzygrok
+TCP_PORT_RANGE=40000-40100
 ```
 
-Start the server:
+`DATABASE_URL` is constructed by `docker/docker-compose.yml` from the PostgreSQL variables above. Developers and CI may set `TEST_DATABASE_URL` for test databases; it is not required for normal production Compose deployment.
+
+Start the server manually:
 
 ```bash
 docker compose up -d
 ```
+
+For the canonical production release path, push a human-approved `v*` tag. The GitHub Actions release workflow builds binaries, publishes release artifacts, SSHes to the production host, copies the pre-built Linux binaries into `bin/`, and restarts Docker Compose. Branch pushes do not deploy production.
 
 ### DNS Configuration
 
@@ -377,8 +384,9 @@ docker exec fonzygrok-server fonzygrok-server token revoke --id tok_abc123 --dat
 | `SSH_PORT` | `2222` | Host port for SSH connections |
 | `HTTP_PORT` | `80` | Host port for HTTP traffic |
 | `HTTPS_PORT` | `443` | Host port for HTTPS traffic |
-| `ADMIN_PORT` | `9090` | Host port for admin API |
-| `DATABASE_URL` | (auto) | PostgreSQL connection string |
+| `ADMIN_PORT` | `9090` | Optional host port for direct admin API access; not exposed by default in Compose |
+| `DATABASE_URL` | (auto) | PostgreSQL connection string constructed by Docker Compose |
+| `TEST_DATABASE_URL` | — | Optional developer/CI test database URL; not used by production Compose |
 | `TCP_PORT_RANGE` | `40000-40100` | TCP tunnel port range |
 | `RATE_LIMIT` | `100` | Requests per second per tunnel |
 | `RATE_BURST` | `200` | Rate limit burst size |


### PR DESCRIPTION
## Summary
- Update GOV-008 to match current PostgreSQL-in-Docker, Alpine runtime, and GitHub Actions tag-triggered release/deploy architecture.
- Update production runbook with tag-triggered deployment guidance and PostgreSQL backup/restore flow.
- Refresh README self-hosting database/deployment notes and MANIFEST summaries.

## Verification
- git diff --check
- Parsed CODEX/00_INDEX/MANIFEST.yaml with PyYAML

Fixes #11