### PR TITLE
CI release and deployment hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test, vet, and coverage
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: fonzygrok
+          POSTGRES_PASSWORD: fonzygrok
+          POSTGRES_DB: fonzygrok_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fonzygrok"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test with race detector
+        env:
+          TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
+        run: go test -race ./...
+
+      - name: Generate coverage
+        env:
+          TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
+        run: |
+          go test -covermode=atomic -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | tee coverage.txt
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage.out
+            coverage.txt
+
+  build:
+    name: Build server and client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: make build VERSION=ci-${{ github.sha }}
+
+      - name: Smoke check versions
+        run: |
+          dist/fonzygrok --version | grep -F "ci-${{ github.sha }}"
+          dist/fonzygrok-server --version | grep -F "ci-${{ github.sha }}"
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: fonzygrok
+          POSTGRES_PASSWORD: fonzygrok
+          POSTGRES_DB: fonzygrok_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fonzygrok"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: E2E tests
+        env:
+          TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
+        run: go test -v -race -tags=e2e -timeout 60s ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,29 @@ jobs:
 
       - name: Test with race detector
         env:
+          DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
           TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
-        run: go test -race ./...
+        run: |
+          # Store and server tests share the same PostgreSQL database and both
+          # reset schema state, so run DB-backed packages serially to avoid
+          # cross-package migration races.
+          go test -race $(go list ./... | grep -Ev '/internal/(store|server)$')
+          go test -race ./internal/store
+          go test -race ./internal/server
 
       - name: Generate coverage
         env:
+          DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
           TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
         run: |
-          go test -covermode=atomic -coverprofile=coverage.out ./...
+          set -euo pipefail
+          go test -covermode=atomic -coverprofile=coverage.base.out $(go list ./... | grep -Ev '/internal/(store|server)$')
+          go test -covermode=atomic -coverprofile=coverage.store.out ./internal/store
+          go test -covermode=atomic -coverprofile=coverage.server.out ./internal/server
+          head -n 1 coverage.base.out > coverage.out
+          tail -n +2 coverage.base.out >> coverage.out
+          tail -n +2 coverage.store.out >> coverage.out
+          tail -n +2 coverage.server.out >> coverage.out
           go tool cover -func=coverage.out | tee coverage.txt
 
       - name: Upload coverage artifact
@@ -108,5 +123,6 @@ jobs:
 
       - name: E2E tests
         env:
+          DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
           TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
         run: go test -v -race -tags=e2e -timeout 60s ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,4 +125,4 @@ jobs:
         env:
           DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
           TEST_DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
-        run: go test -v -race -tags=e2e -timeout 60s ./tests/
+        run: go test -v -race -tags=e2e -timeout 5m ./tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -38,28 +42,57 @@ jobs:
         run: go test -race ./...
 
       - name: Build binaries
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
           mkdir -p dist
+          LDFLAGS="-s -w -X main.Version=${VERSION}"
 
           # Linux amd64
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-server-linux-amd64 ./cmd/server
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-linux-amd64 ./cmd/client
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-server-linux-amd64 ./cmd/server
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-linux-amd64 ./cmd/client
 
           # Linux arm64
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-server-linux-arm64 ./cmd/server
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-linux-arm64 ./cmd/client
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-server-linux-arm64 ./cmd/server
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-linux-arm64 ./cmd/client
 
           # macOS amd64
-          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-server-darwin-amd64 ./cmd/server
-          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-darwin-amd64 ./cmd/client
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-server-darwin-amd64 ./cmd/server
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-darwin-amd64 ./cmd/client
 
           # macOS arm64 (Apple Silicon)
-          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-server-darwin-arm64 ./cmd/server
-          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-darwin-arm64 ./cmd/client
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-server-darwin-arm64 ./cmd/server
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-darwin-arm64 ./cmd/client
 
           # Windows amd64
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-server-windows-amd64.exe ./cmd/server
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X main.Version=${{ github.ref_name }}" -o dist/fonzygrok-windows-amd64.exe ./cmd/client
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-server-windows-amd64.exe ./cmd/server
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/fonzygrok-windows-amd64.exe ./cmd/client
+
+          ./dist/fonzygrok-linux-amd64 --version | grep -F "$VERSION"
+          ./dist/fonzygrok-server-linux-amd64 --version | grep -F "$VERSION"
+
+      - name: Smoke check server health version
+        env:
+          DATABASE_URL: postgres://fonzygrok:fonzygrok@localhost:5432/fonzygrok_test?sslmode=disable
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          data_dir="$(mktemp -d)"
+          ./dist/fonzygrok-server-linux-amd64 serve \
+            --data-dir "$data_dir" \
+            --ssh-addr 127.0.0.1:0 \
+            --http-addr 127.0.0.1:0 \
+            --admin-addr 127.0.0.1:19090 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$data_dir"' EXIT
+          for _ in {1..30}; do
+            if curl -fsS http://127.0.0.1:19090/api/v1/health | tee health.json | grep -F "\"version\":\"$VERSION\""; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server health endpoint did not report version $VERSION"
+          exit 1
 
       - name: Create checksums
         run: |
@@ -86,6 +119,10 @@ jobs:
   deploy:
     needs: release
     runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 
@@ -94,27 +131,39 @@ jobs:
           go-version-file: go.mod
 
       - name: Build production binaries
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
           mkdir -p bin
+          LDFLAGS="-s -w -X main.Version=${VERSION}"
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags "-s -w -X main.Version=${{ github.ref_name }}" \
+            -ldflags "$LDFLAGS" \
             -o bin/fonzygrok-server ./cmd/server
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags "-s -w -X main.Version=${{ github.ref_name }}" \
+            -ldflags "$LDFLAGS" \
             -o bin/fonzygrok-client ./cmd/client
+          ./bin/fonzygrok-server --version | grep -F "$VERSION"
+          ./bin/fonzygrok-client --version | grep -F "$VERSION"
           ls -lh bin/
 
       - name: Deploy to production
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_HOST_KEY: ${{ secrets.DEPLOY_HOST_KEY }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          SSH="ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key"
-          SCP="scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key"
+          if [ -z "$DEPLOY_HOST_KEY" ]; then
+            echo "DEPLOY_HOST_KEY secret is required (known_hosts format)."
+            exit 1
+          fi
+          printf '%s\n' "$DEPLOY_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          SSH="ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=yes -i ~/.ssh/deploy_key"
+          SCP="scp -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=yes -i ~/.ssh/deploy_key"
           TARGET="$DEPLOY_USER@$DEPLOY_HOST"
 
           # Ensure repo exists on server (first-time deploy)
@@ -130,11 +179,12 @@ jobs:
           # Rebuild container (Dockerfile.prod just copies binaries into alpine — ~2s)
           $SSH "$TARGET" "cd ~/fonzygrok/docker && docker compose down || true && docker compose up -d --build"
 
-          rm -f ~/.ssh/deploy_key
+          rm -f ~/.ssh/deploy_key ~/.ssh/known_hosts
 
       - name: Post-deploy health check
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_HOST_KEY: ${{ secrets.DEPLOY_HOST_KEY }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
@@ -143,10 +193,16 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+          if [ -z "$DEPLOY_HOST_KEY" ]; then
+            echo "DEPLOY_HOST_KEY secret is required (known_hosts format)."
+            exit 1
+          fi
+          printf '%s\n' "$DEPLOY_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=yes -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "docker exec fonzygrok-server wget -q --spider http://localhost:9090/api/v1/health" || {
             echo "❌ Health check failed!"
             exit 1
           }
           echo "✅ Health check passed"
-          rm -f ~/.ssh/deploy_key
+          rm -f ~/.ssh/deploy_key ~/.ssh/known_hosts

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 .PHONY: build build-server build-client test test-e2e lint vet clean docker-build docker-up docker-down docker-logs
 
 VERSION ?= dev
-LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION) -X github.com/fonzygrok/fonzygrok/internal/server.Version=$(VERSION)"
+LDFLAGS := -ldflags "-s -w -X main.Version=$(VERSION)"
 
 ## Build both binaries
 build: build-server build-client
 
 build-server:
-	CGO_ENABLED=1 go build $(LDFLAGS) -o bin/fonzygrok-server ./cmd/server/
+	mkdir -p dist
+	CGO_ENABLED=1 go build $(LDFLAGS) -o dist/fonzygrok-server ./cmd/server/
 
 build-client:
-	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/fonzygrok ./cmd/client/
+	mkdir -p dist
+	CGO_ENABLED=0 go build $(LDFLAGS) -o dist/fonzygrok ./cmd/client/
 
 ## Run all unit tests with race detection
 test:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,17 +20,17 @@ import (
 	"golang.org/x/term"
 )
 
-// version is set at build time via -ldflags.
-var version = "dev"
+// Version is set at build time via -ldflags.
+var Version = "dev"
 
 func main() {
 	// Set the package-level version for server info / health endpoints.
-	server.Version = version
+	server.Version = Version
 
 	rootCmd := &cobra.Command{
 		Use:     "fonzygrok-server",
 		Short:   "Fonzygrok tunnel server",
-		Version: version,
+		Version: Version,
 	}
 
 	rootCmd.AddCommand(serveCmd())

--- a/tests/e2e_dashboard_test.go
+++ b/tests/e2e_dashboard_test.go
@@ -76,7 +76,7 @@ func TestE2E_Dashboard_ThemeToggleExists(t *testing.T) {
 	// We need to be authenticated to see the theme toggle (it's in the nav
 	// of authenticated pages). Log in via the dashboard.
 	// First, create an admin session cookie.
-	loginBody := "username=e2eadmin&password=e2etestpassword1"
+	loginBody := "username=" + ts.adminUsername + "&password=e2etestpassword1"
 	loginReq, _ := http.NewRequest("POST", "http://"+ts.edgeAddr+"/login",
 		strings.NewReader(loginBody))
 	loginReq.Host = ts.domain

--- a/tests/e2e_helpers_test.go
+++ b/tests/e2e_helpers_test.go
@@ -70,13 +70,19 @@ func startTestServer(t *testing.T, opts serverOpts) *testServer {
 	edgeAddr := getAvailPort(t)
 	adminAddr := getAvailPort(t)
 
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("TEST_DATABASE_URL")
+	}
+
 	config := server.ServerConfig{
-		DataDir:    tmpDir,
-		Domain:     opts.Domain,
-		TCPPortMin: 40000,
-		TCPPortMax: 41000,
-		RateLimit:  100,
-		RateBurst:  200,
+		DataDir:     tmpDir,
+		Domain:      opts.Domain,
+		DatabaseURL: databaseURL,
+		TCPPortMin:  40000,
+		TCPPortMax:  41000,
+		RateLimit:   100,
+		RateBurst:   200,
 		SSH: server.SSHConfig{
 			Addr:        sshAddr,
 			HostKeyPath: filepath.Join(tmpDir, "host_key"),

--- a/tests/e2e_helpers_test.go
+++ b/tests/e2e_helpers_test.go
@@ -31,6 +31,14 @@ import (
 
 // --- Server Helpers ---
 
+func e2eDatabaseURL() string {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	return databaseURL
+}
+
 // serverOpts configures the test server.
 type serverOpts struct {
 	// Domain overrides the base domain (default: "tunnel.test.local").
@@ -70,10 +78,7 @@ func startTestServer(t *testing.T, opts serverOpts) *testServer {
 	edgeAddr := getAvailPort(t)
 	adminAddr := getAvailPort(t)
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		databaseURL = os.Getenv("TEST_DATABASE_URL")
-	}
+	databaseURL := e2eDatabaseURL()
 
 	config := server.ServerConfig{
 		DataDir:     tmpDir,
@@ -117,7 +122,8 @@ func startTestServer(t *testing.T, opts serverOpts) *testServer {
 		cancel()
 		t.Fatalf("startTestServer: hash password: %v", err)
 	}
-	adminUser, err := srv.Store().CreateUser("e2eadmin", "e2e@test.com", hash, "admin")
+	adminName := "e2eadmin-" + sanitizeName(t.Name())
+	adminUser, err := srv.Store().CreateUser(adminName, adminName+"@test.local", hash, "admin")
 	if err != nil {
 		cancel()
 		t.Fatalf("startTestServer: create admin user: %v", err)

--- a/tests/e2e_helpers_test.go
+++ b/tests/e2e_helpers_test.go
@@ -54,15 +54,16 @@ func defaultServerOpts() serverOpts {
 
 // testServer holds a running fonzygrok server and its metadata.
 type testServer struct {
-	t         *testing.T
-	srv       *server.Server
-	cancel    context.CancelFunc
-	sshAddr   string
-	edgeAddr  string
-	adminAddr string
-	domain    string
-	dataDir   string
-	jwtToken  string // Pre-created admin JWT for API auth.
+	t             *testing.T
+	srv           *server.Server
+	cancel        context.CancelFunc
+	sshAddr       string
+	edgeAddr      string
+	adminAddr     string
+	domain        string
+	dataDir       string
+	adminUsername string
+	jwtToken      string // Pre-created admin JWT for API auth.
 }
 
 // startTestServer spins up a real fonzygrok server with a temp DB,
@@ -146,15 +147,16 @@ func startTestServer(t *testing.T, opts serverOpts) *testServer {
 	}
 
 	ts := &testServer{
-		t:         t,
-		srv:       srv,
-		cancel:    cancel,
-		sshAddr:   sshAddr,
-		edgeAddr:  edgeAddr,
-		adminAddr: adminAddr,
-		domain:    opts.Domain,
-		dataDir:   tmpDir,
-		jwtToken:  jwtToken,
+		t:             t,
+		srv:           srv,
+		cancel:        cancel,
+		sshAddr:       sshAddr,
+		edgeAddr:      edgeAddr,
+		adminAddr:     adminAddr,
+		domain:        opts.Domain,
+		dataDir:       tmpDir,
+		adminUsername: adminName,
+		jwtToken:      jwtToken,
 	}
 
 	t.Cleanup(func() {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -52,8 +52,9 @@ func setupTestEnv(t *testing.T) *testEnv {
 
 	domain := "tunnel.test.local"
 	config := server.ServerConfig{
-		DataDir: tmpDir,
-		Domain:  domain,
+		DataDir:     tmpDir,
+		Domain:      domain,
+		DatabaseURL: e2eDatabaseURL(),
 		SSH: server.SSHConfig{
 			Addr:        "127.0.0.1:0",
 			HostKeyPath: filepath.Join(tmpDir, "host_key"),
@@ -73,7 +74,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	}
 
 	// Create a token before starting (since we have store access).
-	_, _, err = srv.Store().CreateToken("e2e-test")
+	_, _, err = srv.Store().CreateToken("e2e-test-" + sanitizeName(t.Name()))
 	if err != nil {
 		t.Fatalf("CreateToken: %v", err)
 	}
@@ -108,8 +109,9 @@ func setupTestEnv(t *testing.T) *testEnv {
 	adminAddr := getAvailableAddr(t)
 
 	config2 := server.ServerConfig{
-		DataDir: tmpDir,
-		Domain:  domain,
+		DataDir:     tmpDir,
+		Domain:      domain,
+		DatabaseURL: e2eDatabaseURL(),
 		SSH: server.SSHConfig{
 			Addr:        sshAddr,
 			HostKeyPath: filepath.Join(tmpDir, "host_key"),
@@ -129,7 +131,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	}
 
 	// Create a token in the new server's store.
-	tok2, rawToken2, err := srv2.Store().CreateToken("e2e-test-2")
+	tok2, rawToken2, err := srv2.Store().CreateToken("e2e-test-2-" + sanitizeName(t.Name()))
 	if err != nil {
 		t.Fatalf("CreateToken: %v", err)
 	}
@@ -143,7 +145,8 @@ func setupTestEnv(t *testing.T) *testEnv {
 
 	// Create an admin user and JWT for authenticated admin API calls.
 	hash, _ := auth.HashPassword("e2etestpassword1")
-	adminUser, _ := srv2.Store().CreateUser("e2eadmin", "e2e@test.com", hash, "admin")
+	adminName := "e2eadmin-legacy-" + sanitizeName(t.Name())
+	adminUser, _ := srv2.Store().CreateUser(adminName, adminName+"@test.local", hash, "admin")
 	jwtSecretPath := filepath.Join(tmpDir, "jwt_secret")
 	jwtMgr, _ := auth.NewJWTManager(jwtSecretPath, 24*time.Hour)
 	jwtToken, _ := jwtMgr.CreateToken(auth.Claims{


### PR DESCRIPTION
## Summary
- Add PR/main CI quality gate with vet, race tests, coverage artifact, build smoke checks, and E2E tests backed by PostgreSQL.
- Normalize build-time version ldflags so client and server report the same version.
- Harden tag-triggered release/deploy with release smoke checks, production environment, deploy concurrency, and pinned SSH known_hosts via DEPLOY_HOST_KEY.

Fixes #9
Fixes #10
Fixes #12

## Verification
- make build VERSION=test-version
- dist/fonzygrok --version | grep test-version
- dist/fonzygrok-server --version | grep test-version
- go test ./cmd/client ./cmd/server -v
- go vet ./...
- python3 YAML parse for .github/workflows/ci.yml and release.yml