### PR TITLE
fix(server): tighten auth boundaries and invite redemption

### DIFF
--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -19,6 +21,10 @@ import (
 type AdminConfig struct {
 	// Addr is the listen address (e.g., "127.0.0.1:9090").
 	Addr string
+	// AllowedOrigins is an explicit allowlist for credentialed CORS requests.
+	// If empty, safe local-development origins are allowed plus same-origin
+	// requests. Additional origins may be supplied via FONZYGROK_ALLOWED_ORIGINS.
+	AllowedOrigins []string
 }
 
 // AdminAPI serves the admin REST API per CON-002 §4.
@@ -96,21 +102,21 @@ func NewAdminAPI(config AdminConfig, st *store.Store, jwtMgr *auth.JWTManager, t
 	))))
 
 	// Existing admin-only endpoints (now behind auth).
-	a.mux.Handle("/api/v1/tunnels", a.AuthMiddleware(http.HandlerFunc(
+	a.mux.Handle("/api/v1/tunnels", a.AuthMiddleware(a.RequireRole("admin", http.HandlerFunc(
 		a.methodRouteHandler(map[string]http.HandlerFunc{
 			"GET": a.handleListTunnels,
 		}),
-	)))
-	a.mux.Handle("/api/v1/tunnels/", a.AuthMiddleware(http.HandlerFunc(a.handleTunnelSubRoutes)))
-	a.mux.Handle("/api/v1/metrics", a.AuthMiddleware(http.HandlerFunc(
+	))))
+	a.mux.Handle("/api/v1/tunnels/", a.AuthMiddleware(a.RequireRole("admin", http.HandlerFunc(a.handleTunnelSubRoutes))))
+	a.mux.Handle("/api/v1/metrics", a.AuthMiddleware(a.RequireRole("admin", http.HandlerFunc(
 		a.methodRouteHandler(map[string]http.HandlerFunc{
 			"GET": a.handleMetrics,
 		}),
-	)))
+	))))
 
 	a.server = &http.Server{
 		Addr:    config.Addr,
-		Handler: corsMiddleware(a.mux),
+		Handler: corsMiddleware(a.mux, config.AllowedOrigins),
 	}
 
 	return a
@@ -174,15 +180,30 @@ func (a *AdminAPI) methodRouteHandler(handlers map[string]http.HandlerFunc) http
 	return a.methodRoute(handlers)
 }
 
-// corsMiddleware adds CORS headers for web dashboard access.
-func corsMiddleware(next http.Handler) http.Handler {
+// corsMiddleware adds credentialed CORS headers only for trusted origins.
+// It intentionally avoids reflecting arbitrary Origin values because browsers
+// will include cookies on credentialed requests when allowed.
+func corsMiddleware(next http.Handler, configuredOrigins []string) http.Handler {
+	allowedOrigins := map[string]struct{}{
+		"http://localhost:3000": {},
+		"http://127.0.0.1:3000": {},
+		"https://fonzygrok.com": {},
+	}
+	for _, origin := range append(configuredOrigins, splitAllowedOrigins(os.Getenv("FONZYGROK_ALLOWED_ORIGINS"))...) {
+		origin = strings.TrimSpace(origin)
+		if origin != "" {
+			allowedOrigins[origin] = struct{}{}
+		}
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if origin != "" {
+		if origin != "" && isAllowedCORSOrigin(origin, r.Host, allowedOrigins) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Add("Vary", "Origin")
 		}
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusNoContent)
@@ -190,6 +211,24 @@ func corsMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func splitAllowedOrigins(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, ",")
+}
+
+func isAllowedCORSOrigin(origin, host string, allowed map[string]struct{}) bool {
+	if _, ok := allowed[origin]; ok {
+		return true
+	}
+	originURL, err := url.Parse(origin)
+	if err != nil || originURL.Scheme == "" || originURL.Host == "" {
+		return false
+	}
+	return strings.EqualFold(originURL.Host, host)
 }
 
 // --- Endpoint handlers ---
@@ -396,8 +435,6 @@ func (a *AdminAPI) handleListTunnels(w http.ResponseWriter, r *http.Request) {
 	a.writeJSON(w, http.StatusOK, map[string]interface{}{"tunnels": items})
 }
 
-
-
 // handleMetrics returns aggregated metrics across all active tunnels.
 func (a *AdminAPI) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	active := a.tunnels.ListActive()
@@ -422,12 +459,12 @@ func (a *AdminAPI) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	uptime := time.Since(a.startTime).Seconds()
 
 	resp := struct {
-		TotalBytesIn       int64   `json:"total_bytes_in"`
-		TotalBytesOut      int64   `json:"total_bytes_out"`
-		TotalRequestsProxied int64 `json:"total_requests_proxied"`
-		ActiveTunnels      int     `json:"active_tunnels"`
-		ActiveClients      int     `json:"active_clients"`
-		UptimeSeconds      float64 `json:"uptime_seconds"`
+		TotalBytesIn         int64   `json:"total_bytes_in"`
+		TotalBytesOut        int64   `json:"total_bytes_out"`
+		TotalRequestsProxied int64   `json:"total_requests_proxied"`
+		ActiveTunnels        int     `json:"active_tunnels"`
+		ActiveClients        int     `json:"active_clients"`
+		UptimeSeconds        float64 `json:"uptime_seconds"`
 	}{
 		TotalBytesIn:         totalBytesIn,
 		TotalBytesOut:        totalBytesOut,

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -2,11 +2,11 @@
 // user registration, login, logout, and user info.
 //
 // SECURITY:
-// - Passwords are NEVER logged or returned in responses.
-// - Login failures use generic "invalid credentials" — never reveal
-//   whether username or password was wrong.
-// - Registration validates invite code BEFORE creating user to avoid
-//   orphaned accounts.
+//   - Passwords are NEVER logged or returned in responses.
+//   - Login failures use generic "invalid credentials" — never reveal
+//     whether username or password was wrong.
+//   - Registration atomically creates users and redeems invite codes to avoid
+//     invite reuse races and orphaned accounts.
 //
 // REF: SPR-018 T-061, T-062, T-063, T-064
 package server
@@ -34,10 +34,10 @@ const sessionMaxAge = 86400
 //
 // POST /api/v1/register
 //
-// FLOW: validate input → validate invite code → hash password →
-//       create user → redeem invite → issue JWT.
-// DECISION: Validate invite code BEFORE creating user to prevent
-// orphaned users if invite validation fails after user creation.
+// FLOW: validate input → hash password → atomically create user and redeem invite → issue JWT.
+// DECISION: user creation and invite redemption are performed in one store
+// transaction so concurrent registration attempts cannot reuse an invite or
+// leave orphaned users.
 func (a *AdminAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Username   string `json:"username"`
@@ -73,13 +73,6 @@ func (a *AdminAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate invite code BEFORE creating user.
-	invite, err := a.store.ValidateInviteCode(req.InviteCode)
-	if err != nil {
-		a.writeAdminError(w, http.StatusBadRequest, "validation_error", "Invalid or expired invite code")
-		return
-	}
-
 	// Hash password.
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
@@ -88,22 +81,20 @@ func (a *AdminAPI) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create user.
-	user, err := a.store.CreateUser(req.Username, req.Email, hash, "user")
+	// Create user and redeem invite code atomically.
+	user, err := a.store.RegisterUserWithInviteCode(req.Username, req.Email, hash, req.InviteCode)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") || strings.Contains(err.Error(), "unique") {
 			a.writeAdminError(w, http.StatusConflict, "conflict", "Username or email already taken")
 			return
 		}
-		a.logger.Error("register: create user", "error", err)
+		if strings.Contains(err.Error(), "invite code") {
+			a.writeAdminError(w, http.StatusBadRequest, "validation_error", "Invalid or expired invite code")
+			return
+		}
+		a.logger.Error("register: create user with invite", "error", err)
 		a.writeAdminError(w, http.StatusInternalServerError, "internal_error", "Registration failed")
 		return
-	}
-
-	// Redeem invite code.
-	if err := a.store.RedeemInviteCode(invite.ID, user.ID); err != nil {
-		a.logger.Error("register: redeem invite", "error", err, "invite_id", invite.ID)
-		// User was created but invite redeem failed — log but don't fail registration.
 	}
 
 	// Issue JWT.
@@ -364,24 +355,8 @@ func (a *AdminAPI) handleDeleteTokenAuth(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// For non-admin users, verify ownership before delete.
-	if claims.Role != "admin" {
-		tokens, _ := a.store.ListTokens()
-		found := false
-		for _, t := range tokens {
-			if t.ID == tokenID && t.UserID != nil && *t.UserID == claims.UserID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			a.writeAdminError(w, http.StatusNotFound, "not_found", "Token not found")
-			return
-		}
-	}
-
-	if err := a.store.DeleteToken(tokenID); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+	if err := a.store.DeleteTokenForUser(tokenID, claims.UserID, claims.Role); err != nil {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "revoked") {
 			a.writeAdminError(w, http.StatusNotFound, "not_found", "Token not found")
 			return
 		}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -616,6 +616,45 @@ func TestListUsersAdmin(t *testing.T) {
 
 // --- T-068: CORS ---
 
+func TestCORSMiddlewareRejectsUntrustedOriginWithoutDatabase(t *testing.T) {
+	handler := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("untrusted origin must not be reflected, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("untrusted origin must not receive credentials, got %q", got)
+	}
+}
+
+func TestCORSMiddlewareAllowsConfiguredOriginWithoutDatabase(t *testing.T) {
+	handler := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), []string{"https://dashboard.example.com"})
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS status = %d, want 204", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://dashboard.example.com" {
+		t.Fatalf("configured origin should be allowed, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("configured origin should allow credentials, got %q", got)
+	}
+}
+
 func TestCORSHeaders(t *testing.T) {
 	admin, _, st := newTestAdminAPI(t)
 	defer st.Close()
@@ -641,15 +680,39 @@ func TestCORSOnRegularRequest(t *testing.T) {
 	defer st.Close()
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)
-	req.Header.Set("Origin", "http://dashboard.example.com")
+	req.Header.Set("Origin", "http://evil.example.com")
 	w := httptest.NewRecorder()
 	admin.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if w.Header().Get("Access-Control-Allow-Origin") != "http://dashboard.example.com" {
-		t.Error("CORS origin should be echoed on regular requests")
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("untrusted cross-origin request must not receive credentialed CORS headers, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("untrusted cross-origin request must not allow credentials, got %q", got)
+	}
+}
+
+func TestCORSAllowsSameOriginOnlyByDefault(t *testing.T) {
+	admin, _, st := newTestAdminAPI(t)
+	defer st.Close()
+
+	req := httptest.NewRequest("OPTIONS", "http://admin.example.com/api/v1/health", nil)
+	req.Host = "admin.example.com"
+	req.Header.Set("Origin", "http://admin.example.com")
+	w := httptest.NewRecorder()
+	admin.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for OPTIONS, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://admin.example.com" {
+		t.Fatalf("same-origin request should receive CORS allow-origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("same-origin request should allow credentials, got %q", got)
 	}
 }
 
@@ -721,6 +784,36 @@ func TestMetricsEndpointRequiresAuth(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("metrics endpoint should require auth, got %d", w.Code)
+	}
+}
+
+func TestGlobalTunnelEndpointsRequireAdminRole(t *testing.T) {
+	admin, _, st := newTestAdminAPI(t)
+	defer st.Close()
+	userToken := addTestUserAuth(t, admin, st)
+
+	tests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{"GET", "/api/v1/tunnels", ""},
+		{"GET", "/api/v1/metrics", ""},
+		{"DELETE", "/api/v1/tunnels/tun_missing", ""},
+		{"PUT", "/api/v1/tunnels/tun_missing/ratelimit", `{"requests_per_second":1,"burst":1}`},
+		{"PUT", "/api/v1/tunnels/tun_missing/acl", `{"allow_cidrs":["127.0.0.1/32"]}`},
+		{"DELETE", "/api/v1/tunnels/tun_missing/acl", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := authReq(httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body)), userToken)
+			w := httptest.NewRecorder()
+			admin.Handler().ServeHTTP(w, req)
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("expected 403 for non-admin tunnel/metrics endpoint, got %d body=%s", w.Code, w.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -106,7 +106,6 @@ func (d *Dashboard) SetTLSEnabled(enabled bool) {
 	d.tlsEnabled = enabled
 }
 
-
 // RegisterRoutes registers all dashboard routes on the given mux.
 // Called from AdminAPI to share the :9090 listener.
 func (d *Dashboard) RegisterRoutes(mux *http.ServeMux) {
@@ -140,16 +139,16 @@ func (d *Dashboard) RegisterRoutes(mux *http.ServeMux) {
 
 // pageData holds data passed to all templates.
 type pageData struct {
-	Title      string
-	Nav        string
-	Claims     *auth.Claims
-	Flash      string
-	FlashType  string
-	Error      string
+	Title     string
+	Nav       string
+	Claims    *auth.Claims
+	Flash     string
+	FlashType string
+	Error     string
 
 	// Form fields (preserved on error).
 	FormUsername   string
-	FormEmail     string
+	FormEmail      string
 	FormInviteCode string
 
 	// Dashboard data.
@@ -343,14 +342,6 @@ func (d *Dashboard) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate invite code.
-	ic, err := d.store.ValidateInviteCode(inviteCode)
-	if err != nil {
-		formData.Error = "Invalid or already used invite code"
-		d.renderPage(w, "register.html", formData)
-		return
-	}
-
 	// Hash password.
 	hash, err := auth.HashPassword(password)
 	if err != nil {
@@ -360,22 +351,19 @@ func (d *Dashboard) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create user.
-	user, err := d.store.CreateUser(username, email, hash, "user")
+	// Create user and redeem invite code atomically.
+	user, err := d.store.RegisterUserWithInviteCode(username, email, hash, inviteCode)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") || strings.Contains(err.Error(), "unique") {
 			formData.Error = "Username or email already taken"
+		} else if strings.Contains(err.Error(), "invite code") {
+			formData.Error = "Invalid or already used invite code"
 		} else {
-			d.logger.Error("dashboard: create user", "error", err)
+			d.logger.Error("dashboard: create user with invite", "error", err)
 			formData.Error = "Failed to create account"
 		}
 		d.renderPage(w, "register.html", formData)
 		return
-	}
-
-	// Redeem invite code.
-	if err := d.store.RedeemInviteCode(ic.ID, user.ID); err != nil {
-		d.logger.Error("dashboard: redeem invite code", "error", err)
 	}
 
 	// Issue JWT and set cookie.
@@ -515,7 +503,11 @@ func (d *Dashboard) handleTokenAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	claims := claimsFromCtx(r.Context())
-	if err := d.store.DeleteToken(tokenID); err != nil {
+	if err := d.store.DeleteTokenForUser(tokenID, claims.UserID, claims.Role); err != nil {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "revoked") {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
 		d.logger.Error("dashboard: revoke token", "error", err, "token_id", tokenID)
 		http.Error(w, "Failed to revoke token", http.StatusInternalServerError)
 		return
@@ -587,7 +579,6 @@ func (d *Dashboard) renderPage(w http.ResponseWriter, name string, data pageData
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}
 }
-
 
 // setSessionCookie creates a JWT and sets it as an HttpOnly cookie.
 func (d *Dashboard) setSessionCookie(w http.ResponseWriter, user *store.User) {

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -444,9 +444,13 @@ func TestHTMXTokenCreate(t *testing.T) {
 func TestHTMXTokenRevoke(t *testing.T) {
 	mux, _, jwt, st := setupDashboardMux(t)
 	cookie := createTestUser(t, st, jwt, "revokeuser", "user")
+	user, err := st.GetUserByUsername("revokeuser")
+	if err != nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
 
-	// Create a token.
-	tok, _, _ := st.CreateToken("to-revoke", "")
+	// Create a token owned by the logged-in user.
+	tok, _, _ := st.CreateToken("to-revoke", user.ID)
 
 	req := httptest.NewRequest("DELETE", "/dashboard/tokens/"+tok.ID, nil)
 	req.AddCookie(cookie)
@@ -456,6 +460,30 @@ func TestHTMXTokenRevoke(t *testing.T) {
 	resp := w.Result()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("DELETE /dashboard/tokens/:id status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHTMXTokenRevokeRejectsNonOwner(t *testing.T) {
+	mux, _, jwt, st := setupDashboardMux(t)
+	_ = createTestUser(t, st, jwt, "ownerone", "user")
+	otherCookie := createTestUser(t, st, jwt, "ownertwo", "user")
+	owner, err := st.GetUserByUsername("ownerone")
+	if err != nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
+	tok, _, _ := st.CreateToken("not-yours", owner.ID)
+
+	req := httptest.NewRequest("DELETE", "/dashboard/tokens/"+tok.ID, nil)
+	req.AddCookie(otherCookie)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("non-owner DELETE /dashboard/tokens/:id status = %d, want 404", resp.StatusCode)
+	}
+	if _, err := st.ValidateTokenByID(tok.ID); err != nil {
+		t.Fatalf("non-owner delete should leave token active: %v", err)
 	}
 }
 
@@ -585,4 +613,3 @@ func TestLayoutFOUCPreventionScript(t *testing.T) {
 		t.Error("FOUC script (fonzygrok-theme) should appear BEFORE style.css link in <head>")
 	}
 }
-

--- a/internal/store/invite_codes.go
+++ b/internal/store/invite_codes.go
@@ -128,6 +128,90 @@ func (s *Store) RedeemInviteCode(codeID, usedBy string) error {
 	return nil
 }
 
+// RegisterUserWithInviteCode atomically validates and redeems an invite code
+// while creating a user. The invite row is locked for update so concurrent
+// registrations cannot both observe the same invite as unused.
+func (s *Store) RegisterUserWithInviteCode(username, email, passwordHash, inviteCode string) (*User, error) {
+	if username == "" {
+		return nil, fmt.Errorf("store: username is required")
+	}
+	if email == "" {
+		return nil, fmt.Errorf("store: email is required")
+	}
+	if passwordHash == "" {
+		return nil, fmt.Errorf("store: password hash is required")
+	}
+	if inviteCode == "" {
+		return nil, fmt.Errorf("store: invite code is required")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("store: begin registration transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var ic InviteCode
+	var usedBy sql.NullString
+	err = tx.QueryRow(
+		`SELECT id, code, created_by, used_by, used_at, created_at, is_active
+		 FROM invite_codes WHERE code = $1 FOR UPDATE`,
+		inviteCode,
+	).Scan(&ic.ID, &ic.Code, &ic.CreatedBy, &usedBy, &ic.UsedAt, &ic.CreatedAt, &ic.IsActive)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("store: invalid invite code")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: validate invite code: %w", err)
+	}
+	if !ic.IsActive {
+		return nil, fmt.Errorf("store: invite code is deactivated")
+	}
+	if usedBy.Valid {
+		return nil, fmt.Errorf("store: invite code already used")
+	}
+
+	id := UserIDPrefix + auth.RandomHex(12)
+	now := time.Now().UTC()
+	_, err = tx.Exec(
+		`INSERT INTO users (id, username, email, password_hash, role, created_at, is_active)
+		 VALUES ($1, $2, $3, $4, 'user', $5, TRUE)`,
+		id, username, email, passwordHash, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: create user: %w", err)
+	}
+
+	result, err := tx.Exec(
+		`UPDATE invite_codes SET used_by = $1, used_at = $2 WHERE id = $3 AND used_by IS NULL`,
+		id, now, ic.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: redeem invite code: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("store: redeem invite rows affected: %w", err)
+	}
+	if rows == 0 {
+		return nil, fmt.Errorf("store: invite code already redeemed or not found")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("store: commit registration transaction: %w", err)
+	}
+
+	return &User{
+		ID:           id,
+		Username:     username,
+		Email:        email,
+		PasswordHash: passwordHash,
+		Role:         "user",
+		CreatedAt:    now,
+		IsActive:     true,
+	}, nil
+}
+
 // ListInviteCodes returns all invite codes ordered by creation date.
 func (s *Store) ListInviteCodes() ([]InviteCode, error) {
 	rows, err := s.db.Query(

--- a/internal/store/invite_codes_test.go
+++ b/internal/store/invite_codes_test.go
@@ -151,3 +151,28 @@ func TestInviteCodeFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisterUserWithInviteCodeRollsBackUserWhenRedeemFails(t *testing.T) {
+	st := newTestStore(t)
+	defer st.Close()
+
+	admin, _ := st.CreateUser("admin5", "admin5@test.com", "$2a$12$hash", "admin")
+	ic, code, _ := st.CreateInviteCode(admin.ID)
+	redeemer, _ := st.CreateUser("firstredeemer", "firstredeemer@test.com", "$2a$12$hash", "user")
+
+	// Simulate a race: code validates initially, then is redeemed before registration commits.
+	if _, err := st.ValidateInviteCode(code); err != nil {
+		t.Fatalf("ValidateInviteCode: %v", err)
+	}
+	if err := st.RedeemInviteCode(ic.ID, redeemer.ID); err != nil {
+		t.Fatalf("RedeemInviteCode: %v", err)
+	}
+
+	_, err := st.RegisterUserWithInviteCode("raceuser", "race@test.com", "$2a$12$hash", code)
+	if err == nil {
+		t.Fatal("expected registration to fail when invite is concurrently redeemed")
+	}
+	if _, err := st.GetUserByUsername("raceuser"); err == nil {
+		t.Fatal("registration failure must roll back user creation")
+	}
+}

--- a/internal/store/tokens.go
+++ b/internal/store/tokens.go
@@ -115,6 +115,51 @@ func (s *Store) ListTokens() ([]Token, error) {
 	return tokens, nil
 }
 
+// ValidateTokenByID returns an active token by ID. It is intended for
+// ownership checks and post-delete verification; raw token secrets are not
+// needed for these flows.
+func (s *Store) ValidateTokenByID(id string) (*Token, error) {
+	if id == "" {
+		return nil, fmt.Errorf("store: token id is required")
+	}
+
+	var tok Token
+	var userID sql.NullString
+	err := s.db.QueryRow(
+		`SELECT id, name, token_hash, user_id, created_at, last_used_at, is_active FROM tokens WHERE id = $1`,
+		id,
+	).Scan(&tok.ID, &tok.Name, &tok.TokenHash, &userID, &tok.CreatedAt, &tok.LastUsedAt, &tok.IsActive)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("store: token %q not found", id)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: get token by id: %w", err)
+	}
+	if !tok.IsActive {
+		return nil, fmt.Errorf("store: token is revoked")
+	}
+	if userID.Valid {
+		tok.UserID = &userID.String
+	}
+	return &tok, nil
+}
+
+// DeleteTokenForUser marks a token inactive only if the user is authorized.
+// Admin users may delete any token; non-admin users may delete only tokens
+// they own. Unowned legacy tokens are admin-only.
+func (s *Store) DeleteTokenForUser(id, userID, role string) error {
+	tok, err := s.ValidateTokenByID(id)
+	if err != nil {
+		return err
+	}
+	if role != "admin" {
+		if tok.UserID == nil || *tok.UserID != userID {
+			return fmt.Errorf("store: token %q not found", id)
+		}
+	}
+	return s.DeleteToken(id)
+}
+
 // DeleteToken marks a token as inactive (soft delete) by ID.
 // Returns an error if the token does not exist.
 func (s *Store) DeleteToken(id string) error {


### PR DESCRIPTION
## Summary
- Restrict global tunnel/metrics administration to admin users
- Add dashboard token revocation ownership checks using shared store lookup
- Add atomic invite redemption + user creation path to prevent invite reuse races
- Replace arbitrary credentialed CORS origin reflection with explicit/same-origin allowlist behavior

## Test Plan
- [x] `go test ./internal/server -v`
- [x] `go test $(go list ./... | grep -v '/internal/store$')`
- [ ] `TEST_DATABASE_URL=... go test ./internal/store ./internal/server -race -v` (requires PostgreSQL; local PG setup is out of scope)

Fixes #4
Fixes #5
Fixes #6
Fixes #8
