### PR TITLE
Fix streaming responses through HTTP edge

### DIFF
--- a/internal/server/edge.go
+++ b/internal/server/edge.go
@@ -51,6 +51,35 @@ const (
 	defaultHTTPIdleTimeout       = 120 * time.Second
 )
 
+type flushingResponseWriter struct {
+	writer  io.Writer
+	flusher http.Flusher
+}
+
+func (w flushingResponseWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if n > 0 {
+		w.flusher.Flush()
+	}
+	return n, err
+}
+
+func responseBodyWriter(w http.ResponseWriter, resp *http.Response) io.Writer {
+	if !shouldFlushResponse(resp) {
+		return w
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return w
+	}
+	return flushingResponseWriter{writer: w, flusher: flusher}
+}
+
+func shouldFlushResponse(resp *http.Response) bool {
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	return strings.HasPrefix(contentType, "text/event-stream") || resp.ContentLength == -1
+}
+
 // EdgeRouter routes incoming public HTTP requests to the correct tunnel
 // by extracting the subdomain from the Host header and proxying the
 // request through an SSH channel. Per CON-002 §3.
@@ -396,24 +425,22 @@ func (e *EdgeRouter) proxyRequest(w http.ResponseWriter, r *http.Request, entry 
 		}
 		w.WriteHeader(result.resp.StatusCode)
 
-		// Copy response body, counting bytes out.
+		// Copy response body, counting bytes out. Flush streaming responses after
+		// each write so SSE and other long-lived responses reach browsers before
+		// the upstream body closes.
+		bodyWriter := responseBodyWriter(w, result.resp)
 		if entry.Metrics != nil {
-			cw := NewCountingWriter(w, &entry.Metrics.BytesOut)
-			if _, err := io.Copy(cw, result.resp.Body); err != nil {
-				e.logger.Error("edge: copy response body",
-					"tunnel_id", entry.TunnelID,
-					"error", err,
-				)
-			}
+			bodyWriter = NewCountingWriter(bodyWriter, &entry.Metrics.BytesOut)
+		}
+		if _, err := io.Copy(bodyWriter, result.resp.Body); err != nil {
+			e.logger.Error("edge: copy response body",
+				"tunnel_id", entry.TunnelID,
+				"error", err,
+			)
+		}
+		if entry.Metrics != nil {
 			// Record the proxy request.
 			entry.Metrics.RecordRequest()
-		} else {
-			if _, err := io.Copy(w, result.resp.Body); err != nil {
-				e.logger.Error("edge: copy response body",
-					"tunnel_id", entry.TunnelID,
-					"error", err,
-				)
-			}
 		}
 
 		e.logger.Debug("edge: request proxied",

--- a/internal/server/edge.go
+++ b/internal/server/edge.go
@@ -75,6 +75,17 @@ func responseBodyWriter(w http.ResponseWriter, resp *http.Response) io.Writer {
 	return flushingResponseWriter{writer: w, flusher: flusher}
 }
 
+func flushResponseHeaders(w http.ResponseWriter, resp *http.Response) {
+	if !shouldFlushResponse(resp) {
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return
+	}
+	flusher.Flush()
+}
+
 func shouldFlushResponse(resp *http.Response) bool {
 	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
 	return strings.HasPrefix(contentType, "text/event-stream") || resp.ContentLength == -1
@@ -424,6 +435,7 @@ func (e *EdgeRouter) proxyRequest(w http.ResponseWriter, r *http.Request, entry 
 			}
 		}
 		w.WriteHeader(result.resp.StatusCode)
+		flushResponseHeaders(w, result.resp)
 
 		// Copy response body, counting bytes out. Flush streaming responses after
 		// each write so SSE and other long-lived responses reach browsers before

--- a/internal/server/edge_test.go
+++ b/internal/server/edge_test.go
@@ -361,6 +361,25 @@ func TestProxyForwardedHeaders(t *testing.T) {
 
 // --- T-011A: Error Responses ---
 
+func TestResponseBodyWriterFlushesStreamingResponses(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := &http.Response{
+		Header:        http.Header{"Content-Type": {"text/event-stream"}},
+		ContentLength: -1,
+	}
+
+	writer := responseBodyWriter(w, resp)
+	if _, err := writer.Write([]byte(": connected\n\n")); err != nil {
+		t.Fatalf("write streaming response: %v", err)
+	}
+
+	if !w.Flushed {
+		t.Fatal("expected streaming response write to flush immediately")
+	}
+}
+
+// --- T-011A: Error Responses ---
+
 func TestError404TunnelNotFound(t *testing.T) {
 	edge, _, st := newTestEdgeRouter(t)
 	defer st.Close()
@@ -782,12 +801,12 @@ func TestExtractSubdomainWithApexDomain(t *testing.T) {
 		host     string
 		expected string
 	}{
-		{"fonzygrok.com", ""},             // apex domain
-		{"fonzygrok.com:443", ""},         // apex with port
-		{"tunnel.fonzygrok.com", ""},      // base domain
+		{"fonzygrok.com", ""},               // apex domain
+		{"fonzygrok.com:443", ""},           // apex with port
+		{"tunnel.fonzygrok.com", ""},        // base domain
 		{"abc.tunnel.fonzygrok.com", "abc"}, // subdomain
-		{"FONZYGROK.COM", ""},             // case-insensitive apex
-		{"other.com", ""},                 // unrelated
+		{"FONZYGROK.COM", ""},               // case-insensitive apex
+		{"other.com", ""},                   // unrelated
 	}
 
 	for _, tt := range tests {
@@ -952,4 +971,3 @@ var (
 	_ = net.SplitHostPort
 	_ = fmt.Sprintf
 )
-

--- a/internal/server/edge_test.go
+++ b/internal/server/edge_test.go
@@ -359,22 +359,53 @@ func TestProxyForwardedHeaders(t *testing.T) {
 	}
 }
 
-// --- T-011A: Error Responses ---
+// --- T-011A: Streaming Responses ---
 
-func TestResponseBodyWriterFlushesStreamingResponses(t *testing.T) {
+func TestResponseBodyWriterFlushesEventStreamContentType(t *testing.T) {
 	w := httptest.NewRecorder()
 	resp := &http.Response{
-		Header:        http.Header{"Content-Type": {"text/event-stream"}},
-		ContentLength: -1,
+		Header:        http.Header{"Content-Type": {"text/event-stream; charset=utf-8"}},
+		ContentLength: 0,
 	}
 
 	writer := responseBodyWriter(w, resp)
 	if _, err := writer.Write([]byte(": connected\n\n")); err != nil {
-		t.Fatalf("write streaming response: %v", err)
+		t.Fatalf("write SSE response: %v", err)
 	}
 
 	if !w.Flushed {
-		t.Fatal("expected streaming response write to flush immediately")
+		t.Fatal("expected SSE response write to flush immediately")
+	}
+}
+
+func TestResponseBodyWriterFlushesUnknownLengthResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := &http.Response{
+		Header:        http.Header{"Content-Type": {"application/octet-stream"}},
+		ContentLength: -1,
+	}
+
+	writer := responseBodyWriter(w, resp)
+	if _, err := writer.Write([]byte("chunk")); err != nil {
+		t.Fatalf("write unknown-length response: %v", err)
+	}
+
+	if !w.Flushed {
+		t.Fatal("expected unknown-length response write to flush immediately")
+	}
+}
+
+func TestFlushResponseHeadersFlushesStreamingHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := &http.Response{
+		Header:        http.Header{"Content-Type": {"text/event-stream"}},
+		ContentLength: 0,
+	}
+
+	flushResponseHeaders(w, resp)
+
+	if !w.Flushed {
+		t.Fatal("expected streaming headers to flush before the first body chunk")
 	}
 }
 


### PR DESCRIPTION
## Summary
- flush proxied streaming response chunks from the HTTP edge
- treat SSE and unknown-length responses as streaming
- add regression coverage for immediate flush behavior

## Verification
- go test ./internal/server -run 'TestResponseBodyWriterFlushesStreamingResponses|TestProxyForwardsHeaders'
- go test ./internal/server ./internal/client
- go build -o /tmp/fonzygrok-sse-fix ./cmd/client